### PR TITLE
Load token from DevLife folder if Env Vars not present

### DIFF
--- a/src/pytest_devlife/settings.py
+++ b/src/pytest_devlife/settings.py
@@ -5,19 +5,15 @@ import json
 
 def _load_settings_from_disk():
     try:
-        settings_file = osp.join(Path.home(), 'DevLife', '.vscode', 'settings.json')
+        settings_file = Path.home() / 'DevLife' / '.vscode' / 'settings.json'
         with open(settings_file) as f:
             settings = json.load(f)
-            if 'insper.token' in settings and \
-            'insper.hostname' in settings:
-                return {
-                    'token': settings['insper.token'],
-                    'hostname': settings['insper.hostname']
-                }
+            return {
+                'token': settings['insper.token'],
+                'hostname': settings['insper.hostname']
+            }
     except:
-        pass
-
-    raise RuntimeError()
+        raise RuntimeError()
 
 def load_settings():
     token = os.getenv('AUTH_TOKEN')

--- a/src/pytest_devlife/settings.py
+++ b/src/pytest_devlife/settings.py
@@ -1,12 +1,29 @@
 from pathlib import Path
 import os
+import os.path as osp
+import json
 
+def _load_settings_from_disk():
+    try:
+        settings_file = osp.join(Path.home(), 'DevLife', '.vscode', 'settings.json')
+        with open(settings_file) as f:
+            settings = json.load(f)
+            if 'insper.token' in settings and \
+            'insper.hostname' in settings:
+                return {
+                    'token': settings['insper.token'],
+                    'hostname': settings['insper.hostname']
+                }
+    except:
+        pass
+
+    raise RuntimeError()
 
 def load_settings():
     token = os.getenv('AUTH_TOKEN')
     hostname = os.getenv('AUTH_HOSTNAME')
     if not token or not hostname:
-        raise RuntimeError()
+        return _load_settings_from_disk()
     return {
         'token': token,
         'hostname': hostname


### PR DESCRIPTION
Fix #23 . If Env Vars AUTH_TOKEN and AUTH_HOST are not present, load credentials from `~/DevLife/.vscode/settings.json`. 